### PR TITLE
画面幅の表示調整

### DIFF
--- a/src/assets/css/Style.css
+++ b/src/assets/css/Style.css
@@ -22,8 +22,21 @@ body {
 }
 
 .main-content {
-  margin: 0 150px;
-  padding: 24px
+  width: 100%;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+@media (min-width: 768px) {
+  .main-content {
+    max-width: 720px;
+  }
+}
+
+@media (min-width: 992px) {
+  .main-content {
+    max-width: 960px;
+  }
 }
 
 .error-message {
@@ -163,10 +176,16 @@ body {
   flex: 0 0 auto;
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1rem;
+  gap: 1.5rem;
   margin: 1rem auto;
   padding: 0 0.5rem;
+}
+
+@media (min-width: 768px) {
+  .btn-area {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+  }
 }
 
 .age-select {
@@ -460,30 +479,52 @@ body {
   border: 1px solid rgba(0, 0, 0, 0.175);
   border-radius: 0.375rem;
   flex: 0 0 auto;
-  width: 50%;
-  height: 80vh !important;
-  padding: 1.5rem !important;
-  word-wrap: break-word !important;
-  word-break: break-word !important;
+  width: 100%;
+  padding: 1.5rem;
+  word-wrap: break-word;
+  word-break: break-word;
 }
 
 .profile-left {
-  border-top-right-radius: 0;
+  height: 80vh;
+  border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
-  border-right-color: transparent;
+  border-bottom-color: transparent;
 }
 
 .profile-right {
   border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  border-left-color: transparent;
-  overflow-y: auto !important;
+  border-top-right-radius: 0;
+  border-top-color: transparent;
+}
+
+@media (min-width: 768px) {
+  .profile-left {
+    width: 50%;
+    border: 1px solid rgba(0, 0, 0, 0.175);
+    border-radius: 0.375rem;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right-color: transparent;
+  }
+  
+  .profile-right {
+    width: 50%;
+    border: 1px solid rgba(0, 0, 0, 0.175);
+    border-radius: 0.375rem;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left-color: transparent;
+    overflow-y: auto;
+    height: 80vh;
+  }
 }
 
 .edit-profile-btn {
   display: inline-block;
-  padding: 0.375rem 0.75rem;
-  margin: 0 4rem auto 4rem;
+  padding: 0.375rem 2rem;
+  margin: auto;
+  margin-top: 0.5rem;
   font-size: 16px;
   font-weight: 400;
   line-height: 1.5;
@@ -632,11 +673,23 @@ body {
 .list-col {
   flex-shrink: 0;
   flex: 0 0 auto;
-  width: 33.33333333%;
+  width: 100%;
   max-width: 100%;
   padding-right: 0.75rem;
   padding-left: 0.75rem;
   margin-top: 1.5rem;
+}
+
+@media (min-width: 640px) {
+  .list-col {
+    width: 50%;
+  }
+}
+
+@media (min-width: 992px) {
+  .list-col {
+    width: 33.33333333%;
+  }
 }
 
 .target-pic {


### PR DESCRIPTION
## やったこと
### 概要
画面を縮小するときの表示を調整する

### 変更点
- 992pxと768pxの`main-content`を追加
- 新規登録画面とプロフィール編集画面のボタン表示調整
- プロフィール編集ボタンの幅調整
- 画面幅が768px以下の未満のプロフィールカードの表示とborderの調整
- 画面幅が768px以上のときのプロフィールカードの表示とborderの調整
- 画面幅より、一行に表示されるカード数を調整する