### PR TITLE
【追加機能】複数プロフィール写真機能

### DIFF
--- a/src/assets/css/Style.css
+++ b/src/assets/css/Style.css
@@ -425,8 +425,7 @@ body {
 }
 
 .edit-interests-area,
-.edit-description-area,
-.edit-profile-pic-area {
+.edit-description-area {
   flex: 0 0 auto;
   width: 100%;
   max-width: 100%;
@@ -796,4 +795,72 @@ body {
 .like-btn:hover {
   background-color: #157347;
   border-color: #157347;
+}
+
+/* プロフィール写真編集画面 */
+.edit-pic {
+  flex: 0 0 auto;
+  margin: 0.5rem 0.25rem;
+  height: 80px;
+  width: 80px;
+  background-color: #fff;
+  vertical-align: middle;
+  border: 1px solid #dee2e6;
+  border-radius: 50%;
+}
+
+.edit-pic > .bi-person-plus-fill {
+  padding: 15px;
+  display: inline-block;
+  font-family: inherit;
+  font-size: 50px;
+  font-weight: 400;
+  line-height: 1;
+  text-align: center;
+  text-decoration: none;
+  text-transform: none;
+  vertical-align: middle;
+}
+
+.del-pic-btn {
+  display: inline-block;
+  height: 80px;
+  width: 80px;
+  margin: 0.5rem 0.25rem;
+  padding: 0.375rem 0.75rem;
+  font-family: inherit;
+  font-size: 30px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #fff;
+  text-align: center;
+  text-decoration: none;
+  text-transform: none;
+  vertical-align: middle;
+  user-select: none;
+  border: 1px solid #bb1b1b;
+  border-radius: 50%;
+  background-color: #bb1b1b;
+  cursor: pointer;
+}
+
+.del-pic-btn:hover {
+  background-color: #c03030;
+  border-color: #c03030;
+}
+
+.del-pic-btn.disable {
+  background-color: #6c757d;
+  border-color: #6c757d;
+  cursor: not-allowed;
+  pointer-events: none;
+  opacity: 0.65;
+}
+
+.upload-pic-area {
+  flex: 0 0 auto;
+  width: 80%;
+  max-width: 100%;
+  margin-bottom: 1rem;
+  padding: 0 0.5rem;
 }

--- a/src/assets/css/Style.css
+++ b/src/assets/css/Style.css
@@ -521,11 +521,24 @@ body {
   }
 }
 
+.pic-area {
+  display: flex;
+  flex-wrap: wrap;
+  margin: auto;
+}
+
+.profile-btn-area {
+  display: grid;
+  flex: 0 0 auto;
+  width: 300px;
+  gap: 0.5rem;
+  margin: auto;
+  margin-top: 0.5rem;
+}
+
 .edit-profile-btn {
   display: inline-block;
   padding: 0.375rem 2rem;
-  margin: auto;
-  margin-top: 0.5rem;
   font-size: 16px;
   font-weight: 400;
   line-height: 1.5;
@@ -545,7 +558,26 @@ body {
   border-color: #545b62;
 }
 
+.prev-btn, .next-btn {
+  display: inline-block;
+  width: auto;
+  margin: auto;
+  padding: 0;
+  font-size: 35px;
+  font-weight: 400;
+  line-height: 1;
+  color: #dee2e6;
+  text-align: center;
+  text-decoration: none;
+  vertical-align: middle;
+  cursor: pointer;
+  user-select: none;
+  border: none;
+  background-color: transparent;
+}
+
 .profile-pic {
+  display: none;
   height: 300px;
   width: 300px;
   margin: auto;
@@ -553,6 +585,11 @@ body {
   border-radius: 0.375rem;
   border: 1px solid #dee2e6;
   object-fit: scale-down !important;
+}
+
+.profile-pic.active {
+  display: block;
+  position: relative;
 }
 
 .profile-username {

--- a/src/components/CheckValue.php
+++ b/src/components/CheckValue.php
@@ -6,6 +6,7 @@ session_start();
 
 // 画像をDBに格納できる最大のサイズの定数
 define("MAX_SIZE", 1048576);
+define("MAX_PIC", 5);
 
 //異常入出力の確認
 function testInputValue($data) {

--- a/src/database/ProcessProfilePic.php
+++ b/src/database/ProcessProfilePic.php
@@ -1,0 +1,87 @@
+<?php
+// ファイル名： ProcessProfilePic.php
+// コード内容： プロフィール写真編集画面（DBに登録/追加/削除）
+
+include_once("Pdo.php");
+include_once("../components/CheckValue.php");
+
+if (isset($_POST["editProfilePicSubmit"])) {
+  try {
+    $conn->beginTransaction();
+    for ($index = 1; $index <= MAX_PIC; $index++) {
+      $pic = "Pic_$index";
+      $id = "PicId_$index";
+      if (is_uploaded_file($_FILES[$pic]["tmp_name"])) {
+        $name = $_FILES[$pic]["name"];
+        $type = $_FILES[$pic]["type"];
+        $size = $_FILES[$pic]["size"];
+        $tmpName = $_FILES[$pic]["tmp_name"];
+        $picFile = file_get_contents($tmpName);
+        $picContents = base64_encode($picFile);
+        
+        if ($size <= MAX_SIZE) {
+          $picId = $_POST[$id];
+          if (!empty($picId)) {
+            $updatePicSql = 
+              "UPDATE Profile_Pictures SET picture_name = ?, picture_type = ?, 
+              picture_contents = ? WHERE user_id = ? AND picture_id = ?";
+            $stmt = $conn->prepare($updatePicSql);
+            $stmt->bindValue(1, $name);
+            $stmt->bindValue(2, $type);
+            $stmt->bindValue(3, $picContents);
+            $stmt->bindValue(4, getUserIdSession());
+            $stmt->bindValue(5, $picId);
+            $stmt->execute();
+          } else {
+            $uploadPicSql = 
+              "INSERT INTO Profile_Pictures (user_id, picture_name, 
+              picture_type, picture_contents) VALUES (?, ?, ?, ?)";
+            $stmt = $conn->prepare($uploadPicSql);
+            $stmt->bindValue(1, getUserIdSession());
+            $stmt->bindValue(2, $name);
+            $stmt->bindValue(3, $type);
+            $stmt->bindValue(4, $picContents);
+            $stmt->execute();
+          }
+        } else {
+          setErrorMessage("画像サイズが1Mを超えました");
+          $conn->rollback();
+          header("Location: ../pages/EditProfilePic.php");
+          exit;
+        }
+      }
+    }
+    $conn->commit();
+  } catch (PDOException $e) {
+    setErrorMessage("更新失敗: " . $e->getMessage());
+    $conn->rollback();
+    header("Location: ../pages/EditProfilePic.php");
+    exit;
+  }
+  header("Location: ../pages/Profile.php");
+  exit;
+}
+
+if (isset($_POST["delPicSubmit"])) {
+  $uploadedPic = 0;
+  for ($cnt = 1; $cnt <= MAX_PIC; $cnt++) {
+    if (!empty($_POST["PicId_$cnt"])) {
+      $uploadedPic++;
+    }
+  }
+  try {
+    if ($uploadedPic > 1) {
+      $index = $_POST["delPicSubmit"];
+      $deletePicSql = "DELETE FROM Profile_Pictures WHERE picture_id = ?";
+      $stmt = $conn->prepare($deletePicSql);
+      $stmt->bindValue(1, $_POST["PicId_$index"]);
+      $stmt->execute();
+    } else {
+      setErrorMessage("最低写真1枚が必須です");
+    }
+  } catch (PDOException $e) {
+    setErrorMessage("削除失敗: " . $e->getMessage());
+  }
+  header("Location: ../pages/EditProfilePic.php");
+  exit;
+}

--- a/src/database/ProcessProfilePic.php
+++ b/src/database/ProcessProfilePic.php
@@ -20,8 +20,8 @@ if (isset($_POST["editProfilePicSubmit"])) {
         $picContents = base64_encode($picFile);
         
         if ($size <= MAX_SIZE) {
-          $picId = $_POST[$id];
-          if (!empty($picId)) {
+          if (!empty($_POST[$id])) {
+            $picId = $_POST[$id];
             $updatePicSql = 
               "UPDATE Profile_Pictures SET picture_name = ?, picture_type = ?, 
               picture_contents = ? WHERE user_id = ? AND picture_id = ?";
@@ -63,12 +63,7 @@ if (isset($_POST["editProfilePicSubmit"])) {
 }
 
 if (isset($_POST["delPicSubmit"])) {
-  $uploadedPic = 0;
-  for ($cnt = 1; $cnt <= MAX_PIC; $cnt++) {
-    if (!empty($_POST["PicId_$cnt"])) {
-      $uploadedPic++;
-    }
-  }
+  $uploadedPic = $_POST["uploadedPic"];
   try {
     if ($uploadedPic > 1) {
       $index = $_POST["delPicSubmit"];

--- a/src/database/ProcessRegister.php
+++ b/src/database/ProcessRegister.php
@@ -21,9 +21,9 @@ if (isset($_POST["registerUserSubmit"])) {
   if ($inputValue) {
     setErrorMessage("全項目を入力してください");
   } else {
-    // アップロードした画像のサイズ確認
     $validPicType = checkPicType($_FILES["profilePicture"]["name"]);
     if ($validPicType) {
+      // アップロードした画像のサイズ確認
       if ($_FILES["profilePicture"]["size"] > MAX_SIZE) {
         setErrorMessage("画像サイズが1Mを超えました");
       } else {

--- a/src/database/SelectInteractions.php
+++ b/src/database/SelectInteractions.php
@@ -13,7 +13,7 @@ try {
   "SELECT u.user_id, u.username, u.gender, u.age, p.picture_contents, p.picture_type
   FROM Users u LEFT JOIN Profile_Pictures p ON u.user_id = p.user_id
   LEFT JOIN Interactions i ON u.user_id = i.target_user_id AND i.user_id = :LoginId
-  WHERE i.user_id IS NULL AND u.user_id != :LoginId;";
+  WHERE i.user_id IS NULL AND u.user_id != :LoginId GROUP BY u.user_id";
   $stmt = $conn->prepare($interactionListSql);
   $stmt->bindValue(':LoginId', $loginUserId, PDO::PARAM_INT);
   $stmt->execute();

--- a/src/database/SelectMatchedList.php
+++ b/src/database/SelectMatchedList.php
@@ -8,14 +8,12 @@ include_once("../components/CheckValue.php");
 try {
   // マッチ一覧を取得
   $matchedSql = 
-    "SELECT i2.user_id, u.username, u.age, u.description, 
-    pp.picture_contents, pp.picture_type FROM Interactions i1 
-    INNER JOIN Interactions i2 ON i1.user_id = i2.target_user_id 
-    AND i1.target_user_id = i2.user_id
-    INNER JOIN Users u ON i2.user_id = u.user_id
-    INNER JOIN Profile_Pictures pp ON u.user_id = pp.user_id
-    WHERE i1.interaction_type = 'like' AND i2.interaction_type = 'like' 
-    AND i1.user_id = ?";
+  "SELECT i2.user_id, u.username, u.age, u.description, pp.picture_contents, 
+  pp.picture_type FROM Interactions i1 INNER JOIN Interactions i2 
+  ON i1.user_id = i2.target_user_id AND i1.target_user_id = i2.user_id 
+  INNER JOIN Users u ON i2.user_id = u.user_id INNER JOIN Profile_Pictures pp 
+  ON u.user_id = pp.user_id WHERE i1.interaction_type = 'like' 
+  AND i2.interaction_type = 'like' AND i1.user_id = ? GROUP BY i2.user_id";
   $stmt = $conn->prepare($matchedSql);
   $stmt->bindValue(1, getUserIdSession());
   $stmt->execute();

--- a/src/database/SelectProfileItem.php
+++ b/src/database/SelectProfileItem.php
@@ -21,8 +21,7 @@ try {
   // 表示するユーザのプロフィールを取得
   $profileSql = 
     "SELECT u.username, u.gender, u.age, u.blood_type, u.location, u.interests, 
-    u.description, pp.picture_contents, pp.picture_type FROM Users u 
-    LEFT JOIN Profile_Pictures pp ON u.user_id = pp.user_id WHERE u.user_id = ?";
+    u.description FROM Users u WHERE u.user_id = ?";
   $stmt = $conn->prepare($profileSql);
   $stmt->bindValue(1, $displayUserId);
   $stmt->execute();
@@ -39,5 +38,18 @@ $bloodType = testInputValue($profileItem['blood_type']);
 $location = testInputValue($profileItem['location']);
 $interests = testInputValue($profileItem['interests']);
 $description = testInputValue($profileItem['description']);
-$pictureContents = testInputValue($profileItem['picture_contents']);
-$pictureType = testInputValue($profileItem['picture_type']);
+
+try {
+  // 表示するユーザのプロフィール写真を取得
+  $profilePicSql = 
+    "SELECT picture_id, picture_contents, picture_type 
+    FROM Profile_Pictures WHERE user_id = ?";
+  $stmt = $conn->prepare($profilePicSql);
+  $stmt->bindValue(1, $displayUserId);
+  $stmt->execute();
+  
+  $profilePic = $stmt->fetchAll(PDO::FETCH_ASSOC);
+  $row = $stmt->rowCount();
+} catch (PDOException $e) {
+  setErrorMessage("プロフィール項目取得失敗：".$e->getMessage());
+}

--- a/src/database/UpdateEditProfile.php
+++ b/src/database/UpdateEditProfile.php
@@ -11,8 +11,6 @@ if (isset($_POST["editProfileSubmit"])) {
     ($_POST["age"] !== "年齢を選択していください");
   if ($inputValue) {
     try {
-      // トランザクション開始
-      $conn->beginTransaction();
       // 異常入力の確認
       $username = testInputValue($_POST["username"]);
       $age = testInputValue($_POST["age"]);
@@ -37,49 +35,10 @@ if (isset($_POST["editProfileSubmit"])) {
       $stmt->bindValue(8, getUserIdSession());
       $stmt->execute();
       
-      // プロフィール写真を更新しているか
-      $uploadPicture = is_uploaded_file($_FILES["profilePicture"]["tmp_name"]);
-      if ($uploadPicture) {
-        // 画像情報を取得
-        $pictureName = $_FILES["profilePicture"]["name"];
-        $pictureType = $_FILES["profilePicture"]["type"];
-        $pictureSize = $_FILES["profilePicture"]["size"];
-        $pictureTmpName = $_FILES["profilePicture"]["tmp_name"];
-        $pictureFile = file_get_contents($pictureTmpName);
-        $pictureContents = base64_encode($pictureFile);
-        
-        // アップロードした画像のサイズ確認
-        if ($pictureSize <= MAX_SIZE) {
-          //DBを更新する 
-          $updatePictureSql = 
-            "UPDATE Profile_Pictures SET picture_name = ?, picture_type = ?, 
-            picture_contents = ? WHERE user_id = ?";
-          $stmt = $conn->prepare($updatePictureSql);
-          $stmt->bindValue(1, $pictureName);
-          $stmt->bindValue(2, $pictureType);
-          $stmt->bindValue(3, $pictureContents);
-          $stmt->bindValue(4, getUserIdSession());
-          $stmt->execute();
-          
-          // 画像とプロフィール情報が登録成功したらコミットする
-          $conn->commit();
-          header("Location: ../pages/Profile.php");
-          exit;
-        } else {
-          // サイズが1Mを超えたらロールバックする
-          setErrorMessage("画像サイズが1Mを超えました");
-          $conn->rollback();
-        }
-      } else {
-        // プロフィール情報が登録成功したらコミットする
-        $conn->commit();
-        header("Location: ../pages/Profile.php");
-          exit;
-      }
+      header("Location: ../pages/Profile.php");
+      exit;
     } catch (PDOException $e) {
       setErrorMessage("プロフィール更新失敗: " . $e->getMessage());
-      // 片方失敗したらロールバックする
-      $conn->rollback();
     }
   } else {
     setErrorMessage("名前、年齢、性別が必須項目です");

--- a/src/js/CarouselPictures.js
+++ b/src/js/CarouselPictures.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', function () {
+  let carousel = document.querySelector('#pictureCarousel');
+  let items = carousel.querySelectorAll('.profile-pic');
+  let currentIndex = 0;
+
+  function showSlide(index) {
+  items.forEach((item, i) => {
+    item.classList.toggle('active', i === index);
+  });
+  }
+
+  function nextSlide() {
+    currentIndex = (currentIndex + 1) % items.length;
+    showSlide(currentIndex);
+  }
+
+  function prevSlide() {
+    currentIndex = (currentIndex - 1 + items.length) % items.length;
+    showSlide(currentIndex);
+  }
+
+  document.querySelector('.next-btn').addEventListener('click', nextSlide);
+  document.querySelector('.prev-btn').addEventListener('click', prevSlide);
+});

--- a/src/pages/EditProfile.php
+++ b/src/pages/EditProfile.php
@@ -82,16 +82,11 @@
         <div class="edit-description-area">
           <?php profileTextArea($description, "自己紹介", "description"); ?>
         </div>
-        <!-- プロフィール写真 -->
-        <div class="edit-profile-pic-area">
-          <label for="profilePicture" class="input-label">プロフィール写真</label>
-          <input type="file" class="file-input" name="profilePicture" id="profilePicture">
-        </div>
         <div class="btn-area">
           <!-- プロフィール更新ボタン -->
           <input 
-            type="submit" value="プロフィールを更新する" name="editProfileSubmit"
-            formenctype="multipart/form-data" class="btn-update-profile"
+            type="submit" value="プロフィールを更新する" 
+            name="editProfileSubmit" class="btn-update-profile"
           >
           <!-- プロフィール画面に戻るボタン -->
           <a type="button" href='Profile.php' class="btn-return-profile">

--- a/src/pages/EditProfilePic.php
+++ b/src/pages/EditProfilePic.php
@@ -23,13 +23,14 @@
         <!-- プロフィール写真 -->
         <?php 
         for ($index = 1; $index <= MAX_PIC; $index++): 
-          $picCon = testInputValue($profilePic[$index - 1]['picture_contents']);
-          $picType = testInputValue($profilePic[$index - 1]['picture_type']);
-          $picId = testInputValue($profilePic[$index - 1]['picture_id']);
-          
-          if (!empty($picId)) {
+          if (!empty($profilePic[$index - 1]['picture_id'])) {
+            $picCon = testInputValue($profilePic[$index - 1]['picture_contents']);
+            $picType = testInputValue($profilePic[$index - 1]['picture_type']);
+            $picId = testInputValue($profilePic[$index - 1]['picture_id']);
+
             $delBtnClass = "del-pic-btn";
             echo "<img src='data: $picType; base64, $picCon' class='edit-pic'>";
+            echo "<input type='hidden' name='PicId_$index' value='$picId'>";
           } else {
             $delBtnClass = "del-pic-btn disable";
             echo "<div class='edit-pic'><i class='bi-person-plus-fill'></i></div>";
@@ -43,12 +44,12 @@
         </button>
         <div class="upload-pic-area">
           <label class="input-label">プロフィール写真 <?php echo $index; ?></label>
-          <?php echo "<input type='hidden' name='PicId_$index' value='$picId'>"; ?>
           <?php echo "<input type='file' class='file-input' name='Pic_$index' id='Pic_$index'>"; ?>
         </div>
         <?php endfor; ?>
         <div class="btn-area">
           <!-- プロフィール更新ボタン -->
+          <?php echo "<input type='hidden' name='uploadedPic' value='$row'>"; ?>
           <input 
             type="submit" value="写真を更新する" name="editProfilePicSubmit"
             formenctype="multipart/form-data" class="btn-update-profile"

--- a/src/pages/EditProfilePic.php
+++ b/src/pages/EditProfilePic.php
@@ -1,0 +1,65 @@
+<?php
+// ファイル名： EditProfilePic.php
+// コード内容： プロフィール写真編集画面（html部分）
+?>
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <link rel="stylesheet" href="../assets/css/Style.css">
+    <title>プロフィール写真編集画面</title>
+  </head>
+  <body>
+    <?php
+    include_once("../components/CheckValue.php");
+    include_once("../database/SelectProfileItem.php");
+    include_once("../components/CommonTools.php");
+    ?>
+    <main class="main-content">
+      <form method="POST" action="../database/ProcessProfilePic.php" class="form-row">
+        <div class="page-title">プロフィール写真編集</div>
+        <!-- プロフィール写真 -->
+        <?php 
+        for ($index = 1; $index <= MAX_PIC; $index++): 
+          $picCon = testInputValue($profilePic[$index - 1]['picture_contents']);
+          $picType = testInputValue($profilePic[$index - 1]['picture_type']);
+          $picId = testInputValue($profilePic[$index - 1]['picture_id']);
+          
+          if (!empty($picId)) {
+            $delBtnClass = "del-pic-btn";
+            echo "<img src='data: $picType; base64, $picCon' class='edit-pic'>";
+          } else {
+            $delBtnClass = "del-pic-btn disable";
+            echo "<div class='edit-pic'><i class='bi-person-plus-fill'></i></div>";
+          } 
+        ?>
+        <button 
+          type='submit' name='delPicSubmit' formenctype='multipart/form-data'
+          <?php echo "value='$index' class='$delBtnClass'"; ?>
+        >
+          <i class='bi-trash-fill'></i>
+        </button>
+        <div class="upload-pic-area">
+          <label class="input-label">プロフィール写真 <?php echo $index; ?></label>
+          <?php echo "<input type='hidden' name='PicId_$index' value='$picId'>"; ?>
+          <?php echo "<input type='file' class='file-input' name='Pic_$index' id='Pic_$index'>"; ?>
+        </div>
+        <?php endfor; ?>
+        <div class="btn-area">
+          <!-- プロフィール更新ボタン -->
+          <input 
+            type="submit" value="写真を更新する" name="editProfilePicSubmit"
+            formenctype="multipart/form-data" class="btn-update-profile"
+          >
+          <!-- プロフィール画面に戻るボタン -->
+          <a type="button" href='Profile.php' class="btn-return-profile">
+            プロフィール画面に戻る
+          </a>
+        </div>
+      </form>
+      <div class="error-message"><?php displayErrorMessage();?></div>
+    </main>
+  </body>
+</html>

--- a/src/pages/Profile.php
+++ b/src/pages/Profile.php
@@ -72,5 +72,6 @@
         </div>
       </div>
     </main>
+    <script src="../js/CarouselPictures.js"></script>
   </body>
 </html>

--- a/src/pages/Profile.php
+++ b/src/pages/Profile.php
@@ -31,15 +31,33 @@
       <div class="profile">
         <div class="profile-left">
           <!-- プロフィール画像 -->
-          <img 
-            <?php echo "src='data: $pictureType; base64, $pictureContents'"; ?> 
-            alt="profile_picture" class="profile-pic"
-          >
+          <div class="pic-area" id="pictureCarousel">
+            <button class="prev-btn" type="button">
+              <i class="bi-caret-left-fill"></i>
+            </button>
+            <?php 
+            for ($index = 0; $index < $row; $index++) {
+              $picCon = testInputValue($profilePic[$index]['picture_contents']);
+              $picType = testInputValue($profilePic[$index]['picture_type']);
+              if ($index === 0) $picClass = "profile-pic active";
+              else $picClass = "profile-pic";
+              echo "<img src='data: $picType; base64, $picCon' class='$picClass'>";
+            }
+            ?>
+            <button class="next-btn" type="button">
+              <i class="bi-caret-right-fill"></i>
+            </button>
+          </div>
           <!-- 自分のプロフィールを表示されるとき、プロフィール編集ボタンを表示する -->
           <?php if ($displayUserId === getUserIdSession()): ?>
+          <div class="profile-btn-area">
             <a href="EditProfile.php" class="edit-profile-btn" type="button">
               <i class="bi-pencil-fill"></i> プロフィール編集
             </a>
+            <a href="EditProfilePic.php" class="edit-profile-btn" type="button">
+              <i class="bi-camera-fill"></i> プロフィール写真編集
+            </a>
+          </div>
           <?php endif; ?>
         </div>
         <div class="profile-right">


### PR DESCRIPTION
## やったこと
### 概要
プロフィール画面に複数写真をアップロードする機能の追加

### 変更点
- プロフィール画面に写真ボタンと矢印ボタンを追加 [`c27805e`](https://github.com/lamkhjason/dating-website/pull/26/commits/c27805ec67d97127e219a12d44191853c3c93fe5)
- SelectProfileItem.phpで写真の部分を別のSQLにする [`1f8544d`](https://github.com/lamkhjason/dating-website/pull/26/commits/1f8544d55a64efb74af66e46a47d30dae19bc352)
- 複数写真をアップロードする画面を作成 [`2cc89ff`](https://github.com/lamkhjason/dating-website/pull/26/commits/2cc89ffa532974ea1a476d81601f0696d90949a2)
- 写真を追加・更新。削除のDB処理 [`c628bb4`](https://github.com/lamkhjason/dating-website/pull/26/commits/c628bb46ce458a43dc5532559797c0a030555912)
- プロフィール編集にある写真のコードを削除 [`22cedc1`](https://github.com/lamkhjason/dating-website/pull/26/commits/22cedc169e25a61e319e763a7b1ab51316776d4f)
- 写真を変更するためのjavascriptを作成 [`a848432`](https://github.com/lamkhjason/dating-website/pull/26/commits/a8484322a60d27fbcd38e1825d7659ada560ce8b)
- 一覧画面といいね画面のSQLにGROUP BYを追加 [`d310318`](https://github.com/lamkhjason/dating-website/pull/26/commits/d310318cfc1ddbe1dc6bc60da244955ec17f541a)

### 画面レイアウト
<img width="1280" alt="Screenshot 2024-06-20 at 20 09 04" src="https://github.com/lamkhjason/dating-website/assets/162269722/7a647fdf-62f2-426f-a947-c438bfc1008e">
<img width="1280" alt="Screenshot 2024-06-20 at 20 09 22" src="https://github.com/lamkhjason/dating-website/assets/162269722/6e3afb51-33e8-4382-aec3-bd736a072291">